### PR TITLE
Removal of onboarding and expert_review phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,16 @@ This Annotation UI repository has a respective backend repository which can be f
 ## Features
 
 - User authentication (Sign up and Sign in)
-- Four-phase workflow:
-  1. Onboarding
-  2. Annotation
-  3. Review
-  4. Expert Review
+- Two-phase workflow:
+  1. Annotation
+  2. Review
 - Document annotation
 - Answer versioning
 - Flag system for irrelevant questions
 
 ## Phases
 
-### 1. Onboarding
-
-This includes a calibration exercise which allows multiple users to annotate on the same document, to mark them on a scale of 1-5. This ensures the quality of annotators.
-
-### 2. Annotation
+### 1. Annotation
 
 Users can:
 
@@ -32,7 +26,7 @@ Users can:
 - Put together a comprehensive answer to their question
 - View previously annotated answers
 
-### 3. Review
+### 2. Review
 
 In this phase, users can:
 
@@ -40,10 +34,6 @@ In this phase, users can:
 - Modify answers, creating new versions
 - Switch between different answer versions
 - Flag questions deemed irrelevant
-
-### 4. Expert Review
-
-Final review phase for ensuring data quality (details to be added)
 
 ## Technologies
 

--- a/src/Router.test.tsx
+++ b/src/Router.test.tsx
@@ -102,7 +102,7 @@ describe("Router", () => {
     });
   });
 
-  describe("should render review routes when app is in review or expert-review state", () => {
+  describe("should render review routes when app is in review state", () => {
     it("should render review documents list page", async () => {
       render(<Router />, {
         initialEntries: ["/review"],
@@ -116,15 +116,6 @@ describe("Router", () => {
       render(<Router />, {
         initialEntries: ["/review/doc-1"],
         appConfig: { app_state: "review" },
-      });
-
-      expect(screen.getByText("Review Answers page")).toBeInTheDocument();
-    });
-
-    it("should render review qna  page when app state is expert-review", async () => {
-      render(<Router />, {
-        initialEntries: ["/review/doc-1"],
-        appConfig: { app_state: "expert-review" },
       });
 
       expect(screen.getByText("Review Answers page")).toBeInTheDocument();

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -22,12 +22,12 @@ export const Router = () => {
   const homeRoute = (() => {
     switch (app_state) {
       case "annotation":
-      case "onboarding":
         return "/";
       case "review":
-      case "expert-review":
         return "/review";
       case "none":
+        return "/";
+      default:
         return "/";
     }
   })();
@@ -80,7 +80,7 @@ export const Router = () => {
           path="/"
           element={
             <PrivateRoute>
-              {["annotation", "onboarding"].includes(app_state) ? (
+              {["annotation"].includes(app_state) ? (
                 <DocumentsList />
               ) : (
                 <Navigate to={homeRoute} />

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -15,12 +15,8 @@ function getApplicationPhase(appState: AppConfigState["app_state"]) {
   switch (appState) {
     case "annotation":
       return "Annotate";
-    case "onboarding":
-      return "Onboard";
     case "review":
       return "Review";
-    case "expert-review":
-      return "Expert Review";
     case "none":
   }
 }

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -111,7 +111,7 @@ export const AppDrawer = ({
           flex: "1 0 auto",
         }}
       >
-        {["annotation", "onboarding"].includes(appState) && (
+        {["annotation"].includes(appState) && (
           <>
             <NavigationItem
               title="Annotate"
@@ -129,7 +129,7 @@ export const AppDrawer = ({
             />
           </>
         )}
-        {(appState === "review" || appState === "expert-review") && (
+        {(appState === "review") && (
           <NavigationItem
             title="Review Q&A"
             to="/review"

--- a/src/pages/DocumentsList.tsx
+++ b/src/pages/DocumentsList.tsx
@@ -65,7 +65,6 @@ export const DocumentsList = () => {
               onClick={() => handleDocumentClick(doc)}
             >
               <DocumentInfoItem.Title file_name={doc.file_name} />
-              {app_state !== "onboarding" && (
                 <DocumentInfoItem.Actions>
                   {doc.last_edited_by && (
                     <DocumentInfoItem.LastEditedBy
@@ -77,7 +76,6 @@ export const DocumentsList = () => {
                     max_questions={doc.max_questions}
                   />
                 </DocumentInfoItem.Actions>
-              )}
             </DocumentInfoItem>
           </Grid>
         );

--- a/src/pages/MyAnswersList.tsx
+++ b/src/pages/MyAnswersList.tsx
@@ -59,7 +59,6 @@ export const MyAnswersList = () => {
               onClick={() => navigate(`/answers/${doc.id}`)}
             >
               <DocumentInfoItem.Title file_name={doc.file_name} />
-              {app_state !== "onboarding" && (
                 <DocumentInfoItem.Actions>
                   {doc.last_edited_by && (
                     <DocumentInfoItem.LastEditedBy
@@ -71,7 +70,6 @@ export const MyAnswersList = () => {
                     max_questions={doc.max_questions}
                   />
                 </DocumentInfoItem.Actions>
-              )}
             </DocumentInfoItem>
           </Grid>
         );

--- a/src/providers/AppConfigProvider.tsx
+++ b/src/providers/AppConfigProvider.tsx
@@ -1,7 +1,7 @@
 import { createContext, PropsWithChildren } from "react";
 
 export type AppConfigState = {
-  app_state: "annotation" | "review" | "expert-review" | "onboarding" | "none";
+  app_state: "annotation" | "review" | "none";
 };
 
 export const AppConfigContext = createContext<AppConfigState | undefined>(

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -3,7 +3,6 @@ export type DocumentStatus =
   | "QueryFinished"
   | "OnReview"
   | "Reviewed"
-  | "OnExpertReview"
   | "Completed";
 
 export type DocumentInfo = {


### PR DESCRIPTION
fixes #7 

## Changelog:
- Removed expert_review and onboarding phases from the following:
  - AppConfigState
  - AppLayout component
  - Drawer
  - DocumentsList
  - MyAnswers
  - Router
- Removed router test cases related to onboarding and expert_review phase
- Removed OnExpertReview DocumentStatus in api.ts
- Modified Readme file now contains info regarding only the required phases