### PR TITLE
Added dataset information page with a form to index the dataset

### DIFF
--- a/src/components/CreateDatasetForm.tsx
+++ b/src/components/CreateDatasetForm.tsx
@@ -60,21 +60,30 @@ const CreateDatasetForm: React.FC<CreateDatasetFormProps> = ({ open, handleClose
 
   const handleSubmit = async () => {
     const formData = new FormData();
-    formData.append('dataset_name', datasetName);
-    formData.append('dataset_description', description);
+    
+  formData.append('dataset_name', datasetName);
+  formData.append('dataset_description', description);
 
-    files.forEach((file) => {
-      formData.append('files', file);
-    });
-    console.log(formData);
+  files.forEach((file) => {
+    formData.append('files', file); 
+  });
+
+  console.log([...formData.entries()]);  
+  
     try {
-      const response = await makeRequest(`admin/datasets?dataset_name=${datasetName}&dataset_description=${description}`, 'POST', formData);
+      const response = await makeRequest(
+        `admin/datasets?dataset_name=${datasetName}&dataset_description=${description}`, 
+        'POST', 
+        formData
+      );
+      
       toast.info('Dataset upload is successful');
       handleClose(true);
     } catch (err: any) {
       toast.error(`Error: ${err.message || 'Failed to upload dataset'}`);
     }
   };
+  
 
   return (
     <Dialog open={open} onClose={handleClose} PaperProps={{

--- a/src/components/IndexDatasetForm.tsx
+++ b/src/components/IndexDatasetForm.tsx
@@ -1,0 +1,168 @@
+import React, { useState, ChangeEvent, DragEvent } from 'react';
+import { Dialog, DialogActions, DialogContent, DialogTitle, TextField, Button, IconButton, List, ListItem, ListItemText, Typography } from '@mui/material';
+import { CloudUpload, Delete, Close } from '@mui/icons-material';
+import { styled } from '@mui/material/styles';
+import useAxios from '../hooks/useAxios';
+import { toast } from 'react-toastify';
+
+interface IndexDatasetFormProps {
+  open: boolean;
+  handleClose: (successStatus:Boolean) => void;
+  datasetID : string;
+}
+
+const Input = styled('input')({
+  display: 'none',
+});
+
+const IndexDatasetForm: React.FC<IndexDatasetFormProps> = ({ open, handleClose, datasetID }) => {
+  const [OpenAIKey, setOpenAIKey] = useState<string>('');
+  const [ChunkSize, setChunkSize] = useState<string>('');
+  const [ChunkOverlapSize, setChunkOverlapSize] = useState<string>('');
+  
+  const { makeRequest, status, error } = useAxios();
+
+  const handleSubmit = async () => {
+  
+  var data = {
+    "dataset_id": datasetID,
+    "openai_api_key": OpenAIKey,
+    "chunk_size": ChunkSize,
+    "chunk_overlap_size": ChunkOverlapSize
+  }
+  
+    try {
+      console.log(data);
+      // Make a request to upload the dataset
+      const response = await makeRequest(
+        `admin/indexing`, 
+        'POST', 
+        data
+      );
+      
+      toast.info('Dataset indexing successful');
+      handleClose(true); 
+    } catch (err: any) {
+      // Handle error
+      console.log(err);
+      toast.error(`Error: ${err.message || 'Failed to index dataset'}`);
+    }
+  };
+  
+
+  return (
+    <Dialog open={open} onClose={handleClose} PaperProps={{
+      style: {
+        overflowY: 'auto',
+        overflowX: 'clip',
+        backgroundColor: '#f5f5f5',
+      },
+    }}>
+      <DialogTitle style={{ textAlign: 'center', color: 'black' }}>Index Dataset</DialogTitle>
+      <IconButton
+        edge="end"
+        color="inherit"
+        onClick={()=>handleClose(false)}
+        aria-label="close"
+        style={{ position: 'absolute', right: 10, top: 8, color: 'black' }}
+      >
+        <Close />
+      </IconButton>
+      <DialogContent style={{ overflowY: 'clip', color: 'black' }}>
+        <TextField
+          autoFocus
+          margin="dense"
+          label="OpenAI Key"
+          type="text"
+          fullWidth
+          variant="outlined"
+          placeholder="Enter OpenAI Key"
+          value={OpenAIKey}
+          onChange={(e) => setOpenAIKey(e.target.value)}
+          InputProps={{ style: { color: 'black' } }}
+          InputLabelProps={{ style: { color: 'black' } }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              '& fieldset': {
+                borderColor: 'black',
+              },
+              '&:hover fieldset': {
+                borderColor: 'black',
+              },
+              '&.Mui-focused fieldset': {
+                borderColor: 'black',
+              },
+            },
+            '& .MuiInputLabel-root': {
+              color: 'black',
+            },
+          }}
+        />
+        <TextField
+          margin="dense"
+          label="Chunk Size"
+          type="text"
+          fullWidth
+          variant="outlined"
+          placeholder="Enter Chunk Size"
+          value={ChunkSize}
+          onChange={(e) => setChunkSize(e.target.value)}
+          InputProps={{ style: { color: 'black' } }}
+          InputLabelProps={{ style: { color: 'black' } }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              '& fieldset': {
+                borderColor: 'black',
+              },
+              '&:hover fieldset': {
+                borderColor: 'black',
+              },
+              '&.Mui-focused fieldset': {
+                borderColor: 'black',
+              },
+            },
+          }}
+        />
+        <TextField
+          margin="dense"
+          label="Chunk Overlap Size"
+          type="text"
+          fullWidth
+          variant="outlined"
+          placeholder="Enter Chunk Overlap Size"
+          value={ChunkOverlapSize}
+          onChange={(e) => setChunkOverlapSize(e.target.value)}
+          InputProps={{ style: { color: 'black' } }}
+          InputLabelProps={{ style: { color: 'black' } }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              '& fieldset': {
+                borderColor: 'black',
+              },
+              '&:hover fieldset': {
+                borderColor: 'black',
+              },
+              '&.Mui-focused fieldset': {
+                borderColor: 'black',
+              },
+            },
+          }}
+          style={{ paddingBottom: '20px' }}
+        />
+      </DialogContent>
+      <DialogActions style={{ justifyContent: 'center' }}>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          color="primary"
+          style={{ width: '100%', backgroundColor: '#2196F3', fontWeight: '400', fontSize: '1rem' }}
+          disabled={status === 'pending'}
+        >
+          {status === 'pending' ? 'Indexing...' : 'INDEX'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default IndexDatasetForm;

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -5,23 +5,27 @@ import { jwtDecode } from "jwt-decode";
 
 type JWTDecoded = {
   username: string;
-  role: string[]; // Array of roles
+  role: string[];
   exp: number;
 };
 
 export const PrivateRoute = ({ children }: PropsWithChildren) => {
   const { auth } = useAuth();
+  const token = auth.accessToken ?? "";
 
-  if(!auth.accessToken){
-    return <Navigate to={"/signin"} />
+  if (!token) {
+    return <Navigate to="/signin" />;
   }
-  var decodedToken: JWTDecoded | null = null;
-  const token = auth.accessToken??"";
-  if(token!=""){
-     decodedToken = jwtDecode(token);
-  }
-  if (token && !decodedToken?.role.includes("Admin") && window.location.pathname === '/admin') {
+
+  const decodedToken: JWTDecoded = jwtDecode(token);
+
+  if (window.location.pathname === '/admin' && !decodedToken.role.includes("Admin")) {
     return <Navigate to="/" />;
   }
-  return children;
+
+  if (window.location.pathname !== '/admin' && decodedToken.role.includes("Admin")) {
+    return <Navigate to="/admin" />;
+  }
+
+  return <>{children}</>;
 };

--- a/src/mocks/documents.ts
+++ b/src/mocks/documents.ts
@@ -190,3 +190,20 @@ export const questionConfig: QuestionConfigResponse = {
     },
   ],
 };
+
+export const mockDatasets = [
+  {
+    id: 1,
+    name: "Dataset 1",
+    created_at: "2023-10-26",
+    created_by: "John Doe",
+    status: "Active",
+  },
+  {
+    id: 2,
+    name: "Dataset 2",
+    created_at: "2023-10-27",
+    created_by: "Jane Doe",
+    status: "Inactive",
+  },
+];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -9,6 +9,7 @@ import {
   questionConfig,
   reviewDocuments,
   titleDocuments,
+  mockDatasets,
 } from "./documents";
 
 export const handlers = [
@@ -75,5 +76,8 @@ export const handlers = [
 
   http.get("/user/question-config", () => {
     return HttpResponse.json(questionConfig);
+  }),
+  http.get("/admin/datasets", () => {
+    return HttpResponse.json(mockDatasets);
   }),
 ];

--- a/src/pages/AdminPage.test.tsx
+++ b/src/pages/AdminPage.test.tsx
@@ -1,32 +1,18 @@
 import userEvent from "@testing-library/user-event";
+import { AdminPage } from "./AdminPage";
+import { server } from "../mocks/server";
+import { Route, Routes } from "react-router-dom";
 import { render, screen, waitFor } from "../utility/test-utils";
-import {AdminPage} from "./AdminPage";
+
 
 describe("Admin Page", () => {
   it("should render Admin page with datasets", async () => {
-    const mockDatasets = [
-      {
-        name: "Dataset 1",
-        date: "2023-10-26",
-        created_by: "John Doe",
-        status: "Active",
-      },
-      {
-        name: "Dataset 2",
-        date: "2023-10-27",
-        created_by: "Jane Doe",
-        status: "Inactive",
-      },
-    ];
-
-    render(
-        <AdminPage />
-    );
-
+    render(<AdminPage />);
     await waitFor(() => {
       expect(screen.getByText("Annotation UI")).toBeInTheDocument();
     });
   });
+
 
   it("should open and close Create Dataset form", async () => {
     render(
@@ -61,6 +47,55 @@ describe("Admin Page", () => {
     expect(sidebar).toHaveStyle("transform: translateX(-100%)"); // When hidden
     await userEvent.click(hamburgerButton);
     expect(sidebar).toHaveStyle("transform: translateX(0)"); // When visible
+
+  });
+
+  it("should open Dataset information", async () => {
+
+    render(
+      <Routes>
+        <Route path="/" element={<AdminPage />} />
+      </Routes>,
+      { initialEntries: ["/"] }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Annotation UI")).toBeInTheDocument();
+    });
+
+    const datasetCard = await screen.findByText("Dataset 1");
+    userEvent.click(datasetCard);
+
+    await waitFor(() => {
+      expect(screen.getByText("INDEX DATASET")).toBeInTheDocument();
+    });
+  });
+
+  it("should open and submit IndexDatasetForm", async () => {
+
+    render(
+      <Routes>
+        <Route path="/" element={<AdminPage />} />
+      </Routes>,
+      { initialEntries: ["/"] }
+    );
+
+    
+
+    const datasetCard = await screen.findByText("Dataset 1");
+    userEvent.click(datasetCard);
+
+    //Open Dataset Info page
+    await waitFor(() => {
+      expect(screen.getByText("INDEX DATASET")).toBeInTheDocument();
+    });
+
+    const indexButton = screen.getByRole("button", { name: "INDEX DATASET" });
+    userEvent.click(indexButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "INDEX" })).toBeInTheDocument();
+    })
 
   });
 });

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,20 +1,21 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Typography, Button, Grid, Card, CardContent } from '@mui/material';
-import { toast } from "react-toastify";
+import { Box, Typography} from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import DatasetsIcon from '../assets/Datasets.png';
 import ProjectsIcon from '../assets/Projects.png';
 import ListItemIcon from '../assets/ListItem.png';
 import LogoutIcon from '../assets/logout.png';
-import CreateDatasetForm from '../components/CreateDatasetForm';
 import { useAuth } from '../hooks/useAuth';
-import useAxios from '../hooks/useAxios';
+import { DatasetInfo } from './AdminPageComponents/DatasetInfoContent';
+import { MainContent } from './AdminPageComponents/MainContent';
+
 
 const styles = {
   container: {
     display: 'flex',
   },
   sidebar: {
+    zIndex:'5',
     position: 'fixed',
     left: '0',
     height: '100vh',
@@ -44,7 +45,7 @@ const styles = {
     overflow:'auto',
     marginTop: "4rem",
     flex: 1,
-    padding: '20px',
+    // padding: '20px',
     backgroundColor: '#f5f5f5',
     height:'calc(100vh - 4rem)'
   },
@@ -61,25 +62,6 @@ const styles = {
     padding: '10px 0px',
     zIndex: '0'
   },
-  card: {
-    height: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'space-between',
-    backgroundColor:'#D9D9D9',
-    cursor:'pointer',
-    '&:hover': {
-      backgroundColor: '#A0A0A0',
-    },
-  },
-  cardContent: {
-    color:'black',
-    flexGrow: 1,
-  },
-  statusChip: {
-    fontWeight: 'bold',
-    fontSize: '0.75rem',
-  },
   topBar: {
     paddingLeft: '1rem',
     display: 'flex',
@@ -90,7 +72,7 @@ const styles = {
     width: '100vw',
     height: '4rem',
     backgroundColor: '#424242',
-    zIndex: '2',
+    zIndex: '6',
   },
   hamburger: {
     cursor: 'pointer',
@@ -109,106 +91,12 @@ const SidebarItem: React.FC<SidebarItemProps> = ({ pngSrc, label, onClick }) => 
   </Box>
 );
 
-interface DatasetCardProps {
-  name: string;
-  created_at: string;
-  created_by: string;
-  status: string;
-}
-const DatasetCard: React.FC<DatasetCardProps> = ({ name, created_at, created_by, status }) => {
-  const date = new Date(created_at);
-  return (
-    <Card sx={styles.card}>
-      <CardContent sx={styles.cardContent}>
-        <Typography variant="body2" color="black" fontWeight={'bold'} gutterBottom>{name}</Typography>
-        <br/><br/>
-        <Typography variant="body2" color="black" sx={{paddingTop:'20px', fontSize:'0.8rem'}} >{date.toISOString().split('T')[0]}</Typography> 
-        <br/>
-      <Box sx={{ paddingTop: 2, display:'flex', alignItems:'center', justifyContent:'space-between'}}>
-        <Box>
-        <Typography variant="body3" color="black" fontWeight={'bold'}>Created By: </Typography>
-        <Typography variant="body3" color="black">{created_by}</Typography>
-        </Box>
-        <Typography 
-          variant="body2" 
-          sx={{
-            ...styles.statusChip,
-            // backgroundColor: 'white',
-            color: 'black',
-          }}
-        >
-          {status}
-        </Typography>
-      </Box>
-      </CardContent>
-    </Card>
-  );
-};
-
-
-// Content (This is the main content)
-// Create similar structures and route using a Admin Page state variable to navigate
-const Content: React.FC = () => {
-  const { makeRequest, data, status, error } = useAxios<any[]>();
-  const [datasets, setDatasets] = useState<any[]>([]);
-  const [isCreateDatasetFormVisible,setIsCreateDatasetFormVisible] = useState(false);
-
-  // Fetch datasets
-  const fetchDatasets = async () => {
-    try {
-      const response = await makeRequest('admin/datasets', 'GET');
-      if (response) {
-        setDatasets(response);
-      }
-    } catch (err) {
-      toast.error(`Error fetching datasets: + ${err}`);
-      console.error('Error fetching datasets:', err);
-    }
-  };
-
-  useEffect(() => {
-    fetchDatasets();
-  }, []);
-
-  const handleCreateDatasetOpen = () => {
-    setIsCreateDatasetFormVisible(true);
-  };
-  const handleCreateDatasetClose = (successStatus:Boolean) => {
-    if(successStatus){
-      fetchDatasets();
-    }
-    setIsCreateDatasetFormVisible(false);
-  };
-
-  return (
-    <Box>
-      <Box sx={styles.header}>
-        <Button
-          sx={{backgroundColor:"#2196F3", fontWeight:'400'}}
-          variant="contained"
-          color="primary"
-          size="large"
-          onClick={handleCreateDatasetOpen}
-        >
-          + CREATE DATASET
-        </Button>
-      </Box>
-      <CreateDatasetForm open={isCreateDatasetFormVisible} handleClose={(successStatus:Boolean)=>handleCreateDatasetClose(successStatus)}/>
-      <Grid container spacing={3}>
-        {datasets.map((dataset, index) => (
-          <Grid item xs={14} sm={6} md={4} key={index}>
-            <DatasetCard {...dataset} />
-          </Grid>
-        ))}
-      </Grid>
-    </Box>
-  );
-};
 
 //Admin Page (Main page)
 export const AdminPage = () => {
   const { setAuth } = useAuth();
   const navigate = useNavigate();
+  const [selectedDataset, setSelectedDataset] = useState<any | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   
   useEffect(() => {
@@ -223,6 +111,13 @@ export const AdminPage = () => {
   };
   const handleNavbarItemClick = () => {
 
+  };
+  const onDatasetClick = (dataset: any) => {
+    console.log(dataset);
+    setSelectedDataset(dataset);
+  };
+  const ShowDatasetsPage = () => {
+    setSelectedDataset(null);
   };
 
   return (
@@ -241,13 +136,18 @@ export const AdminPage = () => {
           </Box>
         </Box>
         <Box sx={{ ...styles.sidebar, ...(sidebarOpen ? {} : styles.sidebarHidden) }} data-testid="sidebar">
-          <SidebarItem pngSrc={DatasetsIcon} label="Datasets" onClick={handleNavbarItemClick}/>
+          <SidebarItem pngSrc={DatasetsIcon} label="Datasets" onClick={ShowDatasetsPage}/>
           <SidebarItem pngSrc={ProjectsIcon} label="Projects" onClick={handleNavbarItemClick}/>
           <SidebarItem pngSrc={ListItemIcon} label="List item" onClick={handleNavbarItemClick}/>
           <SidebarItem pngSrc={LogoutIcon} label="Logout" onClick={handleLogOut}/>
         </Box>
         <Box sx={{...styles.content,...(sidebarOpen ? {marginLeft:'240px'} : {})}}>
-          <Content/> 
+          {
+          selectedDataset ? 
+          (<DatasetInfo dataset={selectedDataset} handleBack = {ShowDatasetsPage}/>) 
+          : 
+          ( <MainContent onDatasetClick={onDatasetClick} />)
+          }
         </Box>
       </Box>
     </Box>

--- a/src/pages/AdminPageComponents/DatasetCard.tsx
+++ b/src/pages/AdminPageComponents/DatasetCard.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Card, CardContent, Typography, Box } from '@mui/material';
+
+const styles = {
+    card: {
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        backgroundColor:'#D9D9D9',
+        cursor:'pointer',
+        '&:hover': {
+          backgroundColor: '#A0A0A0',
+        },
+      },
+      cardContent: {
+        color:'black',
+        flexGrow: 1,
+      },
+      statusChip: {
+        fontWeight: 'bold',
+        fontSize: '0.75rem',
+      },
+};
+
+interface DatasetCardProps {
+  name: string;
+  created_at: string;
+  created_by: string;
+  status: string;
+  onClick: () => void;
+}
+
+export const DatasetCard: React.FC<DatasetCardProps> = ({ name, created_at, created_by, status, onClick }) => {
+  const date = new Date(created_at);
+
+  return (
+    <Card sx={styles.card} onClick={onClick}>
+      <CardContent sx={styles.cardContent}>
+        <Typography variant="body2" color="black" fontWeight={'bold'} gutterBottom>{name}</Typography>
+        <br/><br/>
+        <Typography variant="body2" color="black" sx={{paddingTop:'20px', fontSize:'0.8rem'}} >{date.toISOString().split('T')[0]}</Typography> 
+        <br/>
+      <Box sx={{ paddingTop: 2, display:'flex', alignItems:'center', justifyContent:'space-between'}}>
+        <Box>
+        <Typography variant="body3" color="black" fontWeight={'bold'}>Created By: </Typography>
+        <Typography variant="body3" color="black">{created_by}</Typography>
+        </Box>
+        <Typography 
+          variant="body2" 
+          sx={{
+            ...styles.statusChip,
+            color: 'black',
+          }}
+        >
+          {status}
+        </Typography>
+      </Box>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/pages/AdminPageComponents/DatasetInfoContent.tsx
+++ b/src/pages/AdminPageComponents/DatasetInfoContent.tsx
@@ -1,0 +1,188 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Typography, Paper, Button, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+import useAxios from '../../hooks/useAxios';
+import { toast } from 'react-toastify';
+import IndexDatasetForm from '../../components/IndexDatasetForm';
+import { LoadingSpinner } from "../../components/LoadingSpinner";
+
+
+interface DatasetInfoProps {
+  dataset: {
+    id: string;
+    name: string;
+    created_at: string;
+    created_by: string;
+    status: string;
+    description?: string;
+  };
+  handleBack: () => void;
+}
+
+interface FileInfo {
+  annotator : string;
+  reviewer : string;
+  file_name : string;
+  size: string;
+  status: string;
+}
+
+const styles = {
+  container: {
+    padding: '20px',
+    color: 'black', 
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '20px',
+    position: 'sticky',
+    top: '0',
+    right: '0',
+    backgroundColor: '#f5f5f5',
+    padding: '10px 0px',
+    zIndex: '0'
+  },
+  datasetName: {
+    color: 'black',
+  },
+  indexButton: {
+    backgroundColor: '#4285F4',
+    color: 'white',
+    '&:hover': {
+      backgroundColor: '#3367D6',
+    },
+  },
+  tableContainer: {
+    boxShadow: 'none',
+    borderRadius: '0px',
+    marginTop: '20px',
+  },
+  table: {
+    Border: '2px solid black',
+  },
+  tableHeader: {
+    fontWeight: 'bold',
+    backgroundColor: '#F0F0F2',
+  },
+  tableBody: {
+    backgroundColor: '#F3F3F3',
+  },
+  tableRow: {
+  },
+  tableCellHeader: {
+    fontWeight: 'bold',
+    color: 'black',
+    borderTop: '1px solid grey', 
+    borderLeft: '2px solid #333',
+    borderRight: '2px solid #333',
+  },
+  tableCell: {
+    color: 'black',
+    borderTop: '2px solid lightGrey', 
+    borderLeft: '2px solid #333',
+    borderRight: '2px solid #333',
+  },
+  backButton: {
+    marginBottom: 2,
+    color: 'black',
+    textTransform: 'none',
+  },
+};
+
+export const DatasetInfo: React.FC<DatasetInfoProps> = ({ dataset, handleBack }) => {
+  const { makeRequest } = useAxios<any>();
+  const [files, setFiles] = useState<FileInfo[]>([]);
+  const [isIndexDatasetFormVisible, setIsIndexDatasetFormVisible] = useState(false);
+  const [datasetState, setDatasetState] = useState(dataset);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchDatasetInfo = async () => {
+    setDatasetState(dataset);
+    try {
+      const response = await makeRequest(`admin/datasets/${datasetState.id}`, 'GET');
+      if (response) {
+        console.log(response);
+        setFiles(response);
+        setIsLoading(false);
+      }
+    } catch (err) {
+      toast.error(`Error fetching dataset info: ${err}`);
+      console.error('Error fetching dataset info:', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchDatasetInfo();
+  }, [datasetState.id]);
+
+  const handleIndexDataset = () => {
+    toast.info('Indexing dataset...');
+  };
+  const handleIndexDatasetOpen = () => {
+    setIsIndexDatasetFormVisible(true);
+  };
+
+  const handleIndexDatasetClose = (successStatus: Boolean) => {
+    if (successStatus) {
+      fetchDatasetInfo();
+      setDatasetState({...datasetState,status:"Indexed"});
+    }
+    setIsIndexDatasetFormVisible(false);
+  };
+
+  if(isLoading){
+    return(    
+      <LoadingSpinner/>
+    );
+  }
+
+  return (
+    <Box sx={styles.container}>
+      {/* <Button onClick={handleBack} sx={styles.backButton}>
+        Back to List
+      </Button> */}
+      <IndexDatasetForm open={isIndexDatasetFormVisible} handleClose={(successStatus:Boolean)=>handleIndexDatasetClose(successStatus)} datasetID={datasetState.id}/>
+      <Box sx={styles.header}>
+        <Typography variant="h5" sx={styles.datasetName}>
+          {datasetState.name}
+        </Typography>
+        {datasetState.status!="Indexed" ?  <Button
+          sx={{ backgroundColor: "#2196F3", fontWeight: '400' }}
+          variant="contained"
+          color="primary"
+          size="large"
+          onClick={handleIndexDatasetOpen}
+        >
+          INDEX DATASET
+        </Button> : <h3>INDEXED</h3>
+        }
+        
+      </Box>
+      <TableContainer component={Paper} sx={styles.tableContainer}>
+        <Table sx={{border:'2px solid black'}}>
+          <TableHead sx={styles.tableHeader}>
+            <TableRow>
+              <TableCell sx={styles.tableCellHeader}>Filename</TableCell>
+              <TableCell sx={styles.tableCellHeader}>Size</TableCell>
+              <TableCell sx={styles.tableCellHeader}>Status</TableCell>
+              <TableCell sx={styles.tableCellHeader}>Annotator</TableCell>
+              <TableCell sx={styles.tableCellHeader}>Reviewer</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody sx={styles.tableBody}>
+            {files.map((file, index) => (
+              <TableRow key={index}>
+                <TableCell sx={styles.tableCell}>{file.file_name}</TableCell>
+                <TableCell sx={styles.tableCell}>{file.size}</TableCell>
+                <TableCell sx={styles.tableCell}>{file.status}</TableCell>
+                <TableCell sx={styles.tableCell}>{file.annotator??'-'}</TableCell>
+                <TableCell sx={styles.tableCell}>{file.reviewer??'-'}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};

--- a/src/pages/AdminPageComponents/MainContent.tsx
+++ b/src/pages/AdminPageComponents/MainContent.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Button, Grid } from '@mui/material';
+import { toast } from "react-toastify";
+import CreateDatasetForm from '../../components/CreateDatasetForm';
+import useAxios from '../../hooks/useAxios';
+import { DatasetCard } from './DatasetCard';
+import { LoadingSpinner } from "../../components/LoadingSpinner";
+
+const styles = {
+  header: {
+    color: 'black',
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    marginBottom: '20px',
+    position: 'sticky',
+    top: '0',
+    right: '0',
+    backgroundColor: '#f5f5f5',
+    padding: '10px 0px',
+    zIndex: '0'
+  },
+  main: {
+    padding: '20px',
+  }
+};
+
+interface ContentProps {
+  onDatasetClick: (dataset: any) => void;
+}
+
+export const MainContent: React.FC<ContentProps> = ({ onDatasetClick }) => {
+  const { makeRequest } = useAxios<any[]>();
+  const [datasets, setDatasets] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isCreateDatasetFormVisible, setIsCreateDatasetFormVisible] = useState(false);
+
+  const fetchDatasets = async () => {
+    try {
+      const response = await makeRequest('/admin/datasets', 'GET');
+      if (response) {
+        console.log(response);
+        setDatasets(response);
+      }
+    } catch (err) {
+      toast.error(`Error fetching datasets: ${err}`);
+      console.error('Error fetching datasets:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchDatasets();
+  }, []);
+
+  const handleCreateDatasetOpen = () => {
+    setIsCreateDatasetFormVisible(true);
+  };
+
+  const handleCreateDatasetClose = (successStatus: Boolean) => {
+    if (successStatus) {
+      fetchDatasets();
+    }
+    setIsCreateDatasetFormVisible(false);
+  };
+
+  if(isLoading){
+    return(<LoadingSpinner/>)
+  }
+
+  return (
+    <Box sx={styles.main}>
+      <Box sx={styles.header}>
+        <Button
+          sx={{ backgroundColor: "#2196F3", fontWeight: '400' }}
+          variant="contained"
+          color="primary"
+          size="large"
+          onClick={handleCreateDatasetOpen}
+        >
+          + CREATE DATASET
+        </Button>
+      </Box>
+      <CreateDatasetForm open={isCreateDatasetFormVisible} handleClose={(successStatus: Boolean) => handleCreateDatasetClose(successStatus)} />
+      <Grid container spacing={3}>
+        {(
+          datasets.map((dataset, index) => (
+            <Grid item xs={14} sm={6} md={4} key={index}>
+              <DatasetCard {...dataset} onClick={() => onDatasetClick(dataset)} />
+            </Grid>
+          ))
+        )}
+      </Grid>
+    </Box>
+  );
+};


### PR DESCRIPTION
Fixes Issue #10 

## Changelog 

- Added a page to display dataset information
  - Clicking on a dataset card on the home screen of Admin UI will open up this page
  - The Index Dataset button opens up a form to make a post request to index the dataset
  
  ![image](https://github.com/user-attachments/assets/dd534310-c9e2-46d0-9bf1-5522a2df54fc)
- Added form to index the dataset 

   ![image](https://github.com/user-attachments/assets/7652b159-86e7-4df9-96da-802c15e796a0)
- Added test cases for the UI
  - Included mockDatasets inside mock documents file
  - Included datasets route in mock handler
  - Included test cases for Dataset-Information page inside AdminPage.test
- Optimized the code for private route 
- Divided Admin page into multiple components for scalability